### PR TITLE
Shapefile export fixes

### DIFF
--- a/TNAtoolAPI-Webapp/src/main/java/com/model/database/DatabaseConfig.java
+++ b/TNAtoolAPI-Webapp/src/main/java/com/model/database/DatabaseConfig.java
@@ -40,12 +40,8 @@ import au.com.bytecode.opencsv.CSVWriter;
 
 public class DatabaseConfig {
     // Class methods
-    private static final Map<String, DatabaseConfig> dbIndex = new HashMap<String, DatabaseConfig>();
-
-    static {
-        System.out.println("DatabaseConfig::static");
-        loadDefault();
-    }
+    private static String lastPath;
+    private static HashMap<String, DatabaseConfig> dbIndex;
 
     public static String ConfigurationDirectory() {
         return System.getProperty("edu.oregonstate.tnatool.ConfigurationDirectory");
@@ -57,6 +53,9 @@ public class DatabaseConfig {
     }
 
     public static void loadFromCsvPath(String path) {
+        // discard existing
+        dbIndex = new HashMap<String, DatabaseConfig>();
+        // load csv
         System.out.println("DatabaseConfig.loadFromCsvPath: " + path);
         CSVReader reader = null;
         try {
@@ -71,13 +70,20 @@ public class DatabaseConfig {
         } catch (IOException e) {
             e.printStackTrace();
         }
+        // Save last path
+        lastPath = path;
+    }
+
+    public static void reload() {
+        loadFromCsvPath(lastPath);
     }
 
     public static DatabaseConfig getConfig(int index) {
-        return dbIndex.get(new Integer(index).toString());
+        return getConfig(Integer.toString(index));
     }
 
     public static DatabaseConfig getConfig(String index) {
+        if (lastPath == null) { loadDefault(); }
         return dbIndex.get(index);
     }
 
@@ -121,7 +127,7 @@ public class DatabaseConfig {
     }
     
     // to/from CSV
-    public String[] asArray() {
+    public String[] toArray() {
         // backwards compat
         String[] row = { getDatabaseIndex(), getDbName(), getSpatialConfigPath(), getConfigPath(), getConnectionUrl(),
                 getUsername(), getPassword(), getCensusMappingSource(), getGtfsMappingSource1(),
@@ -149,14 +155,14 @@ public class DatabaseConfig {
         return uri.getHost();
     }
 
-    public int getPort() {
+    public String getPort() {
         URI uri = URI.create(getConnectionUrl().replace("jdbc:",""));
-        return uri.getPort();        
+        return Integer.toString(uri.getPort());
     }
     
     public String getDatabase() {
         URI uri = URI.create(getConnectionUrl().replace("jdbc:",""));
-        return uri.getPath();        
+        return uri.getPath().substring(1);        
     }
 
     // Getters

--- a/TNAtoolAPI-Webapp/src/main/java/com/model/database/Databases.java
+++ b/TNAtoolAPI-Webapp/src/main/java/com/model/database/Databases.java
@@ -48,7 +48,19 @@ public class Databases {
             : Databases.class.getProtectionDomain().getCodeSource().getLocation().getPath() + "../../src/main/resources/";
     }
 
-    public static String dbInfoCsvPath() { 
+		public static String DownloadablesDirectory() {
+			System.err.format(
+							"Loading downloadables directory from property edu.oregonstate.tnatool.DownloadablesDirectory: %s, "
+							+  "or falling back to getProtectionDomain().getCodeSource().getLocation().getPath() + ../../src/main/webapp/downloadables %s\n",
+							System.getProperty("edu.oregonstate.tnatool.DownloadablesDirectory"),
+							Databases.class.getProtectionDomain().getCodeSource().getLocation().getPath());
+			return
+					( System.getProperty("edu.oregonstate.tnatool.DownloadablesDirectory") != null )
+					? System.getProperty("edu.oregonstate.tnatool.DownloadablesDirectory") + '/'
+					: Databases.class.getProtectionDomain().getCodeSource().getLocation().getPath() + "../../src/main/webapp/downloadables";
+		}
+
+    public static String dbInfoCsvPath() {
         String path = ConfigurationDirectory() + "/admin/resources/dbInfo.csv";
         System.err.format( "dbInfoCsvPath called, path is: %s \n", path);
         return path;

--- a/TNAtoolAPI-Webapp/src/main/java/com/webapp/api/Queries.java
+++ b/TNAtoolAPI-Webapp/src/main/java/com/webapp/api/Queries.java
@@ -245,15 +245,13 @@ public class Queries {
 
 		// get database parameters
 		// ian todo: database selector
-		BufferedReader reader = new BufferedReader(new FileReader(Databases.databaseParamsCsvPath()));
+		BufferedReader reader = new BufferedReader(new FileReader(Databases.dbInfoCsvPath()));
 		reader.readLine();
 		String[] params = reader.readLine().trim().split(",");
 		reader.close();
 
 		// Make temporary directory for shapefile export
-		// Path tmpdir = Files.createTempDirectory("shapefiles");
-		// File.createTempFile("shapefiles", Long.toString(System.nanoTime()));
-		File tmpdir = new File("/tmp", "shapefiles-"+Long.toString(System.nanoTime()));
+		File tmpdir = new File(System.getProperty("java.io.tmpdir"), "shapefiles-"+Long.toString(System.nanoTime()));
 		tmpdir.mkdirs();
 		System.out.println("shapefile export to tmpdir: " + tmpdir);
 

--- a/TNAtoolAPI-Webapp/src/main/java/com/webapp/api/Queries.java
+++ b/TNAtoolAPI-Webapp/src/main/java/com/webapp/api/Queries.java
@@ -74,6 +74,7 @@ import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.operation.TransformException;
 
 import com.model.database.Databases;
+import com.model.database.DatabaseConfig;
 import com.model.database.onebusaway.gtfs.hibernate.ext.GtfsHibernateReaderExampleMain;
 import com.model.database.queries.EventManager;
 import com.model.database.queries.FlexibleReportEventManager;
@@ -245,10 +246,7 @@ public class Queries {
 
 		// get database parameters
 		// ian todo: database selector
-		BufferedReader reader = new BufferedReader(new FileReader(Databases.dbInfoCsvPath()));
-		reader.readLine();
-		String[] params = reader.readLine().trim().split(",");
-		reader.close();
+		DatabaseConfig db = DatabaseConfig.getConfig(dbIndex);
 
 		// Make temporary directory for shapefile export
 		File tmpdir = new File(System.getProperty("java.io.tmpdir"), "shapefiles-"+Long.toString(System.nanoTime()));
@@ -281,7 +279,7 @@ public class Queries {
 						+ " WHERE trips.agencyid = '" + agencyId + "'");
 			} else if (flag.equals("stops")) {
 				// check if the number of records are larger than a threshold, split stops_times in to multiple shapefiles
-				Connection connection = PgisEventManager.makeConnection(dbIndex);
+				Connection connection = db.getConnection();
 			    Statement stmt = connection.createStatement();
 			    int THRESHOLD = 750000;
 			    ResultSet rs = stmt.executeQuery("SELECT count(gid) FROM gtfs_stop_times AS stoptimes WHERE stoptimes.trip_agencyid ='" + agencyId + "'");
@@ -373,11 +371,11 @@ public class Queries {
 				String[] cmd = {
 					"pgsql2shp",
 					"-f", shapePath,
-					"-h", params[0],
-					"-p",  params[1],
-					"-u", params[2],
-					"-P", params[3],
-					dbName,
+					"-h", db.getHost(),
+					"-p", db.getPort(),
+					"-u", db.getUsername(),
+					"-P", db.getPassword(),
+					db.getDatabase(),
 					query.get(j)
 				};
 				System.out.println(Arrays.toString(cmd));


### PR DESCRIPTION
Fix shapefile exporter

- Downloadables directory method and configuration parameter
- Fixes to path handling
- Portable call to `pgsql2shp`
- Remove .bat script
- Use temporary directory

TODO:
- [x] Database selector method, remove all direct reads of .csv file
- [x] Remove hard coded /tmp

See #65 